### PR TITLE
workflows: Forgot action type

### DIFF
--- a/.github/workflows/devstageprod.yml
+++ b/.github/workflows/devstageprod.yml
@@ -13,6 +13,7 @@ on:
         description: 'Action to be performed by Terraform'
         required: true
         default: 'apply'
+        type: choice
         options:
           - 'apply'
           - 'destroy'


### PR DESCRIPTION
Workflow did not present a set of predefined options as it should, but that is now fixed by setting 'type: choice'