### PR TITLE
Update Terraform files for backend storage account and resource group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ crash.*.log
 # password, private keys, and other secrets. These should not be part of version 
 # control as they are data points which are potentially sensitive and subject 
 # to change depending on the environment.
-*.tfvars
+#*.tfvars
 *.tfvars.json
 
 # Ignore override files as they are usually used to override resources locally and so

--- a/backend/terraform.tfvars
+++ b/backend/terraform.tfvars
@@ -1,0 +1,11 @@
+# Resource Group
+rg_backend_name = "pbj-rg-backend"
+rg_backend_location = "westeurope"
+
+# Storage Account
+sa_backend_name = "sabets"
+sc_backend_name = "tfstate"
+
+# Key Vault
+kv_backend_name = "kvbe"
+sa_backend_accesskey_name = "pbj-sa-backend-accesskey"

--- a/terraform/storageaccount.tf
+++ b/terraform/storageaccount.tf
@@ -3,7 +3,7 @@ resource "azurerm_storage_account" "sa" {
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = azurerm_resource_group.rg.location
   account_tier             = "Standard"
-  account_replication_type = "GRS"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_container" "sc" {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,35 @@
+###### General variables ######
+base_name = "test"
+rg_name = "rg"
+location = "westeurope"
+
+##########################################
+###### Variable for the keyvault.tf ######
+##########################################
+
+kv_name = "kv"
+sa_accesskey_name = "sa-accesskey"
+
+################################################
+###### Variable for the storageaccount.tf ######
+################################################
+
+sa_name = "sa"
+sc_name = "sc"
+
+#################################################
+###### Variables for the virtualnetwork.tf ######
+#################################################
+
+vnet_name = "vnet"
+nsg_name = "nsg"
+subnet_name = "subnet"
+
+#################################################
+###### Variables for the virtualmachine.tf ######
+#################################################
+
+vm_nic_name = "vm-nic"
+vm_name = "vm"
+pip_name = "pip"
+vm_usernm = "myadminuser"


### PR DESCRIPTION
This pull request updates the Terraform files to use a new backend storage account and resource group. It also changes the account replication type for the storage account from GRS to LRS. Additionally, it adds new variables for the key vault, storage account, virtual network, and virtual machine.

Commits included:

- Create terraform.tfvars

- fix: variable name in terraform.tfvars

- Testing workflow

- Changed account-replication type